### PR TITLE
Need to be able to control the max heap used by the JVM

### DIFF
--- a/2.4.0/Dockerfile
+++ b/2.4.0/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER mansante <mansante@gmail.com>
 
 ENV HORNETQ_VERSION 2.4.0.Final 
 ENV HORNETQ_HOME /opt/hornetq-${HORNETQ_VERSION}
+ENV JAVA_MAX_HEAP 1024
 
 RUN mkdir ${HORNETQ_HOME} \
   && curl -sSL http://downloads.jboss.org/hornetq/hornetq-${HORNETQ_VERSION}-bin.tar.gz \

--- a/2.4.0/run.sh
+++ b/2.4.0/run.sh
@@ -25,7 +25,7 @@ export CLASSPATH=$RESOLVED_CONFIG_DIR:$HORNETQ_HOME/schemas/
 # Use the following line to run with different ports
 export CLUSTER_PROPS="-Djnp.port=1099 -Djnp.rmiPort=1098 -Djnp.host=$HORNETQ_HOST -Dhornetq.remoting.netty.host=$HORNETQ_HOST -Dhornetq.remoting.netty.port=5445"
 
-export JVM_ARGS="$CLUSTER_PROPS -XX:+UseParallelGC -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Xms512M -Xmx1024M -Dhornetq.config.dir=$RESOLVED_CONFIG_DIR -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dlogging.configuration=file://$RESOLVED_CONFIG_DIR/logging.properties -Djava.library.path=./lib/linux-i686:./lib/linux-x86_64"
+export JVM_ARGS="$CLUSTER_PROPS -XX:+UseParallelGC -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Xms512M -Xmx$JAVA_MAX_HEAP -Dhornetq.config.dir=$RESOLVED_CONFIG_DIR -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dlogging.configuration=file://$RESOLVED_CONFIG_DIR/logging.properties -Djava.library.path=./lib/linux-i686:./lib/linux-x86_64"
 
 # Use the following line to debug
 #export JVM_ARGS="-Djnp.host=$HORNETQ_HOST -Djava.rmi.server.hostname=$HORNETQ_HOST -Dhornetq.remoting.netty.host=$HORNETQ_HOST -Xmx512M -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dlogging.configuration=$CONFIG_DIR/logging.properties -Dhornetq.config.dir=$CONFIG_DIR -Djava.library.path=. -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005"


### PR DESCRIPTION
I need to be able to control how much heap space is able to be used by the HornetQ jvm and this is the easiest way. This will allow a dockerfile based on this one to overwrite the given JVM Max heap size and then use it in the shell script.

If we dont do it this way, it will require a completely overwritten shell script which can be done but is much more of a pain